### PR TITLE
fix url issue for Windows users

### DIFF
--- a/src/main/java/org/cogcomp/Datastore.java
+++ b/src/main/java/org/cogcomp/Datastore.java
@@ -472,7 +472,7 @@ public class Datastore {
         String fileNameWithoutExtension = artifactId.replace(extension, "");
         fileNameWithoutExtension + "-" + Double.toString(version) + (extension.equals("")? "": "." + extension);
         */
-        return version + File.separator + artifactId;
+        return version + "/" + artifactId;
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Use "/" for the url in all server requests, instead of File.Separator, which is "\" in Windows.